### PR TITLE
fix: honor timeouts for long sync check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 description = "Run a closure continuously, until is succeeds or times out."
 license = "MIT"
-license-file = "LICENSE"
 readme = "README.md"
 rust-version = "1.70"
 authors = [

--- a/README.md
+++ b/README.md
@@ -128,11 +128,16 @@ cargo run --example async-std --features=async-std
 If you'd like to control more finely the intervals and how many times a check will occur, you can create the `Waiter` object(s) yourself:
 
 ```rust
+use situwaition::runtime::AsyncWaiter;
+use situwaition::runtime::SyncWaiter;
+
 // Synchronous code
-situwaition::sync::SyncWaiter::with_timeout(|| { ... }, Duration::from_millis(500));
+SyncWaiter::with_timeout(|| { ... }, Duration::from_millis(500))?;
 
 // Asynchronous code (either tokio or async-std)
-situwaition::runtime::AsyncWaiter::with_timeout(|| async { ... }, Duration::from_millis(500)).exect().await;
+AsyncWaiter::with_timeout(|| async { ... }, Duration::from_millis(500))?
+    .exec()
+    .await;
 ```
 
 See the methods on [`SyncWaiter`](./src/sync.rs) and [`AsyncWaiter`](./src/runtime/mod.rs) for more options.

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -46,11 +46,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(matches!(result, 42));
     eprintln!("resulting value is: {}", result);
 
-    // An always failing example
-    let result = AsyncWaiter::with_timeout(
+    // This async waiter always fails, so it will resolve to a failure in 500ms
+    let _ = AsyncWaiter::with_timeout(
         || async { Err(ExampleError::NotDoneCountingError) as Result<(), ExampleError> },
         Duration::from_millis(500),
-    )
+    )?
     .exec()
     .await;
     eprintln!("asynchronous always-failling result: {:?}", result);

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = situwaition::sync::SyncWaiter::with_timeout(
         || Err(ExampleError::NotDoneCountingError) as Result<(), ExampleError>,
         Duration::from_millis(500),
-    )
+    )?
     .exec();
     eprintln!("synchronous always-failling result: {:?}", result);
 

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -46,11 +46,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(matches!(result, 42));
     eprintln!("resulting value is: {}", result);
 
-    // An always failing example
-    let result = AsyncWaiter::with_timeout(
+    // This async waiter always fails, so it will resolve to a failure in 500ms
+    let _ = AsyncWaiter::with_timeout(
         || async { Err(ExampleError::NotDoneCountingError) as Result<(), ExampleError> },
         Duration::from_millis(500),
-    )
+    )?
     .exec()
     .await;
     eprintln!("asynchronous always-failling result: {:?}", result);

--- a/src/runtime/tokio.rs
+++ b/src/runtime/tokio.rs
@@ -3,7 +3,7 @@
 use std::{error::Error, future::Future};
 
 use async_trait::async_trait;
-use tokio::time::{sleep, Instant};
+use tokio::time::{sleep, timeout, Instant};
 
 use crate::{AsyncSituwaition, SituwaitionError};
 
@@ -19,12 +19,22 @@ where
 {
     async fn exec(&mut self) -> Result<R, SituwaitionError<E>> {
         let start = Instant::now();
+        let check_timeout = self.opts.timeout;
+        let cooldown = self.opts.check_cooldown;
 
         loop {
             let fut = (self.factory)();
-            match fut.await {
-                Ok(v) => return Ok(v),
-                Err(e) => {
+            match timeout(check_timeout, fut).await {
+                // Check completed in time and successfully and we can return
+                Ok(Ok(v)) => return Ok(v),
+                // Check timed out
+                Err(_) => return Err(SituwaitionError::CheckTimeoutError),
+                // Check completed in time but failed
+                Ok(Err(e)) => {
+                    if let Some(t) = cooldown {
+                        sleep(t).await;
+                    }
+
                     if Instant::now() - start > self.opts.timeout {
                         return Err(SituwaitionError::TimeoutError(e));
                     }
@@ -71,7 +81,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unit_tokio_async_executor_from_fn() {
+    async fn test_unit_tokio_from_fn() {
         assert!(
             matches!(
                 AsyncWaiter::from_factory(|| async { Ok::<bool, std::io::Error>(true) })
@@ -84,7 +94,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unit_tokio_async_executor_exec_fail() {
+    async fn test_unit_tokio_exec_fail() {
         assert!(matches!(
             AsyncWaiter::with_timeout(
                 || async {
@@ -92,6 +102,7 @@ mod tests {
                 },
                 Duration::from_millis(500)
             )
+            .expect("failed to create")
             .exec()
             .await,
             Err(SituwaitionError::TimeoutError(std::io::Error { .. })),
@@ -99,13 +110,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unit_tokio_async_executor_exec_pass() {
+    async fn test_unit_tokio_exec_pass() {
         assert!(
             matches!(
                 AsyncWaiter::with_check_interval(
                     || async { Ok::<bool, std::io::Error>(true) },
                     Duration::from_millis(100),
                 )
+                .expect("failed to create")
                 .exec()
                 .await,
                 Ok(true)
@@ -115,7 +127,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unit_tokio_wait_for_async_executor_with_timeout() {
+    async fn test_unit_tokio_wait_for_with_timeout() {
         let start = tokio::time::Instant::now();
 
         assert!(
@@ -126,6 +138,7 @@ mod tests {
                     },
                     Duration::from_millis(500),
                 )
+                .expect("failed to create")
                 .exec()
                 .await,
                 Err(SituwaitionError::TimeoutError(std::io::Error { .. })),
@@ -139,7 +152,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unit_tokio_async_executor_with_check_interval() {
+    async fn test_unit_tokio_with_check_interval() {
         let start = Instant::now();
 
         assert!(
@@ -148,6 +161,7 @@ mod tests {
                     || async { Ok::<bool, std::io::Error>(true) },
                     Duration::from_millis(100)
                 )
+                .expect("failed to create")
                 .exec()
                 .await,
                 Ok(true)
@@ -157,6 +171,31 @@ mod tests {
         assert!(
             Instant::now() - start < Duration::from_millis(250),
             "passed faster than default interval (250ms) w/ shorter interval"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unit_tokio_with_long_check() {
+        let start = Instant::now();
+        assert!(
+            matches!(
+                AsyncWaiter::with_timeout(
+                    || async {
+                        sleep(Duration::from_millis(500)).await;
+                        Ok::<bool, std::io::Error>(true)
+                    },
+                    Duration::from_millis(250)
+                )
+                .expect("failed to create")
+                .exec()
+                .await,
+                Err(SituwaitionError::CheckTimeoutError),
+            ),
+            "check that finishes in 500ms times out in 100ms as configured"
+        );
+        assert!(
+            Instant::now() - start < Duration::from_millis(500),
+            "timed out before the check completed"
         );
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,21 +1,35 @@
 use std::{
+    sync::{Arc, Mutex},
     thread::sleep,
     time::{Duration, Instant},
 };
 
-use crate::{SituwaitionBase, SituwaitionError, SituwaitionOpts, SyncSituwaition};
+use crate::{
+    SituwaitionBase, SituwaitionError, SituwaitionOpts, SyncSituwaition, WaiterCreationError,
+    DEFAULT_SITUWAITION_CHECK_INTERVAL_MS, DEFAULT_SITUWAITION_TIMEOUT_MS,
+};
 
 /// Synchronous situwaitioner
 #[allow(dead_code)]
-pub struct SyncWaiter<R, E> {
+pub struct SyncWaiter<R, E, F>
+where
+    R: Send,
+    E: Send + 'static,
+    F: Fn() -> Result<R, E> + Send + Sync + 'static,
+{
     /// Options for the situwaition
     opts: SituwaitionOpts,
 
     /// Function that can be run to decide whether the executor should finish
-    check_fn: Box<dyn Fn() -> Result<R, E>>,
+    check_fn: Option<Box<F>>,
 }
 
-impl<R, E> SituwaitionBase for SyncWaiter<R, E> {
+impl<R, E, F> SituwaitionBase for SyncWaiter<R, E, F>
+where
+    R: Send,
+    E: Send + 'static,
+    F: Fn() -> Result<R, E> + Send + Sync + 'static,
+{
     type Result = R;
     type Error = E;
 
@@ -32,74 +46,140 @@ impl<R, E> SituwaitionBase for SyncWaiter<R, E> {
     }
 }
 
-impl<R, E> SyncSituwaition for SyncWaiter<R, E> {
-    fn exec(&self) -> Result<R, SituwaitionError<E>> {
+impl<R, E, F> SyncSituwaition for SyncWaiter<R, E, F>
+where
+    R: Send + 'static,
+    E: Send + 'static,
+    F: Fn() -> Result<R, E> + Send + Sync + 'static,
+{
+    fn exec(&mut self) -> Result<R, SituwaitionError<E>> {
         let start = Instant::now();
 
-        // Run the situwaition until it succeeds
-        loop {
-            match (self.check_fn)() {
-                Ok(v) => break Ok(v),
+        let check_fn = self
+            .check_fn
+            .take()
+            .ok_or_else(|| SituwaitionError::UnexpectedError("no check fn specified".into()))?;
+
+        let result = Mutex::new(None);
+        let result_read = Arc::new(result);
+        let result_write = result_read.clone();
+
+        let err: Mutex<Option<SituwaitionError<E>>> = Mutex::new(None);
+        let err_read = Arc::new(err);
+        let err_write = err_read.clone();
+
+        let timeout = self.opts.timeout;
+        let check_cooldown = self.opts.check_cooldown;
+
+        // We run the check function in a scoped thread in order to ensure
+        // that we can handle the case where the check function never returns in time
+        std::thread::spawn(move || loop {
+            let res = check_fn();
+            match res {
+                Ok(v) => {
+                    let mut mutex = result_write.lock().map_err(|_| ())?;
+                    *mutex = Some(v);
+                    break Ok::<(), ()>(());
+                }
                 Err(e) => {
                     let now = Instant::now();
-                    if now - start > self.opts.timeout {
-                        break Err(SituwaitionError::TimeoutError(e));
+                    if now - start > timeout {
+                        let mut mutex = err_write.lock().map_err(|_| ())?;
+                        *mutex = Some(SituwaitionError::TimeoutError(e));
+                        break Ok::<(), ()>(());
+                    }
+
+                    // If a cooldown was specified, wait a bit
+                    if let Some(t) = check_cooldown {
+                        sleep(t);
                     }
                 }
             }
+        });
 
-            // busy wait for the check interval
+        // Wait until the handle is finished, without being blocked by it
+        loop {
+            // Sleep & check for timeout until finished
+            match (result_read.lock(), err_read.lock()) {
+                (Ok(mut r), Ok(mut err)) => {
+                    // If an error has returned, it *must* be the timeout error, return that quickly
+                    if err.is_some() {
+                        return Err((*err).take().unwrap());
+                    }
+
+                    // If we've timed out otherwise while doing the check, we timed out *during* a check
+                    if Instant::now() - start > self.opts.timeout {
+                        return Err(SituwaitionError::CheckTimeoutError);
+                    }
+
+                    // If a result came through, we can return that happily
+                    if r.is_some() {
+                        return Ok((*r).take().unwrap());
+                    }
+                }
+                _ => panic!("failed to lock mutex"),
+            }
+            // Sleep before checking again
             sleep(self.opts.check_interval);
         }
     }
 }
 
 #[allow(dead_code)]
-impl<R, E> SyncWaiter<R, E> {
-    pub fn from_fn(check_fn: impl Fn() -> Result<R, E> + 'static) -> SyncWaiter<R, E> {
+impl<R, E, F> SyncWaiter<R, E, F>
+where
+    R: Send + 'static,
+    E: Send + 'static,
+    F: Fn() -> Result<R, E> + Send + Sync + 'static,
+{
+    pub fn from_fn(check_fn: F) -> Self {
         SyncWaiter {
             opts: SituwaitionOpts::default(),
-            check_fn: Box::new(check_fn),
+            check_fn: Some(Box::new(check_fn)),
         }
     }
 
     /// Create a sync executor with options fully specified
-    pub fn with_opts(
-        check_fn: impl Fn() -> Result<R, E> + 'static,
-        opts: SituwaitionOpts,
-    ) -> SyncWaiter<R, E> {
+    pub fn with_opts(check_fn: F, opts: SituwaitionOpts) -> Self {
         SyncWaiter {
             opts,
-            check_fn: Box::new(check_fn),
+            check_fn: Some(Box::new(check_fn)),
         }
     }
 
     /// Create a SyncWaiter with only timeout customized
-    pub fn with_timeout(
-        check_fn: impl Fn() -> Result<R, E> + 'static,
-        timeout: Duration,
-    ) -> SyncWaiter<R, E> {
-        Self::with_opts(
-            Box::new(check_fn),
+    pub fn with_timeout(check_fn: F, timeout: Duration) -> Result<Self, WaiterCreationError> {
+        if timeout < Duration::from_millis(DEFAULT_SITUWAITION_CHECK_INTERVAL_MS) {
+            return Err(WaiterCreationError::InvalidTimeout(
+                format!("supplied timeout ({}ms) is shorter the default timeout ({DEFAULT_SITUWAITION_CHECK_INTERVAL_MS}ms)", timeout.as_millis())
+            ));
+        }
+        Ok(Self::with_opts(
+            check_fn,
             SituwaitionOpts {
                 timeout,
                 ..SituwaitionOpts::default()
             },
-        )
+        ))
     }
 
     /// Create a SyncWaiter with only check interval customized
     pub fn with_check_interval(
-        check_fn: impl Fn() -> Result<R, E> + 'static,
+        check_fn: F,
         check_interval: Duration,
-    ) -> SyncWaiter<R, E> {
-        Self::with_opts(
-            Box::new(check_fn),
+    ) -> Result<Self, WaiterCreationError> {
+        if check_interval > Duration::from_millis(DEFAULT_SITUWAITION_TIMEOUT_MS) {
+            return Err(WaiterCreationError::InvalidTimeout(
+                format!("supplied check interval ({}ms) is larger than the default timeout ({DEFAULT_SITUWAITION_TIMEOUT_MS}ms)", check_interval.as_millis())
+            ));
+        }
+        Ok(Self::with_opts(
+            check_fn,
             SituwaitionOpts {
                 check_interval,
                 ..SituwaitionOpts::default()
             },
-        )
+        ))
     }
 }
 
@@ -112,11 +192,11 @@ impl<R, E> SyncWaiter<R, E> {
 /// Returning a result (as opposed to the error) will end waiting, otherwise
 /// the function will be retried up until the default timeout (see SituwaitionOpts)
 #[allow(dead_code)]
-pub fn wait_for<R, E>(
-    check_fn: impl Fn() -> Result<R, E> + 'static,
-) -> Result<R, SituwaitionError<E>>
+pub fn wait_for<R, E, F>(check_fn: F) -> Result<R, SituwaitionError<E>>
 where
-    E: std::error::Error,
+    R: Send + 'static,
+    E: std::error::Error + Send + 'static,
+    F: Fn() -> Result<R, E> + Send + Sync + 'static,
 {
     SyncWaiter::from_fn(check_fn).exec()
 }
@@ -153,6 +233,7 @@ mod tests {
                 || Err::<(), std::io::Error>(std::io::Error::new(ErrorKind::Other, "test")),
                 Duration::from_millis(500)
             )
+            .expect("failed to create")
             .exec(),
             Err(SituwaitionError::TimeoutError(std::io::Error { .. })),
         ),);
@@ -166,6 +247,7 @@ mod tests {
                     || Ok::<bool, std::io::Error>(true),
                     Duration::from_millis(100)
                 )
+                .expect("failed to create")
                 .exec(),
                 Ok(true)
             ),
@@ -181,7 +263,9 @@ mod tests {
                 SyncWaiter::with_timeout(
                     || Err::<(), std::io::Error>(std::io::Error::new(ErrorKind::Other, "test")),
                     Duration::from_millis(500)
-                ).exec(),
+                )
+                .expect("failed to create")
+                .exec(),
                 Err(SituwaitionError::TimeoutError(std::io::Error { .. })),
             ),
             "always erroring check fails in 100ms with timeout of 100ms"
@@ -200,7 +284,9 @@ mod tests {
                 SyncWaiter::with_check_interval(
                     || Ok::<bool, std::io::Error>(true),
                     Duration::from_millis(100)
-                ).exec(),
+                )
+                .expect("failed to create")
+                .exec(),
                 Ok(true)
             ),
             "always passing check passes in 100m with check interval of 100ms"
@@ -208,6 +294,30 @@ mod tests {
         assert!(
             Instant::now() - start < Duration::from_millis(250),
             "passed faster than default interval"
+        );
+    }
+
+    #[test]
+    fn test_unit_sync_executor_with_long_check() {
+        let start = Instant::now();
+        assert!(
+            matches!(
+                SyncWaiter::with_timeout(
+                    || {
+                        std::thread::sleep(Duration::from_millis(500));
+                        Ok::<bool, std::io::Error>(true)
+                    },
+                    Duration::from_millis(250)
+                )
+                .expect("failed to create")
+                .exec(),
+                Err(SituwaitionError::CheckTimeoutError),
+            ),
+            "check that finishes in 500ms times out in 100ms as configured"
+        );
+        assert!(
+            Instant::now() - start < Duration::from_millis(500),
+            "timed out before the check completed"
         );
     }
 }


### PR DESCRIPTION
Resolves #4 

As of PR creation, the new check passes and none of the others do:

```console
cargo nextest run -E 'test(test_unit_sync_executor_with_long_check)'
```

A couple things left:
- [x] Investigate using `RwLock` instead of `Mutex`
- [x] Finish implementing the cases in the check loop
